### PR TITLE
Fixing occasional crash in the native android FastImageView library.

### DIFF
--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewWithUrl.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewWithUrl.java
@@ -61,8 +61,14 @@ class FastImageViewWithUrl extends ImageView {
     }
 
     private void _applyLoopCount(GifDrawable drawable, int loopCount) {
+        GifDrawableAccessor.setIsRunning(drawable, false);
+        GifDrawableAccessor.setFrameLoaderIsRunning(drawable, false);
+
         drawable.setLoopCount(loopCount);
         drawable.stop();
         drawable.startFromFirstFrame();
+
+        GifDrawableAccessor.setFrameLoaderIsRunning(drawable, true);
+        GifDrawableAccessor.setIsRunning(drawable, true);
     }
 }

--- a/android/src/main/java/com/dylanvann/fastimage/GifDrawableAccessor.java
+++ b/android/src/main/java/com/dylanvann/fastimage/GifDrawableAccessor.java
@@ -1,0 +1,41 @@
+package com.dylanvann.fastimage;
+
+import android.graphics.drawable.Drawable;
+import com.bumptech.glide.load.resource.gif.GifDrawable;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public class GifDrawableAccessor {
+    public static void setIsRunning(GifDrawable gifDrawable, boolean isRunning) {
+        try {
+            Method method = gifDrawable.getClass().getDeclaredMethod("setIsRunning", boolean.class);
+            method.setAccessible(true);
+            method.invoke(gifDrawable, isRunning);
+        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static void setFrameLoaderIsRunning(GifDrawable gifDrawable, boolean isRunning) {
+        Drawable.ConstantState gifState = gifDrawable.getConstantState();
+        try {
+            Field field = gifState.getClass().getDeclaredField("frameLoader");
+            field.setAccessible(true);
+            Object gifFrameLoader = field.get(gifState);
+            Class gifFrameLoaderClass = Class.forName("com.bumptech.glide.load.resource.gif.GifFrameLoader");
+
+            if(isRunning) {
+                Method start = gifFrameLoaderClass.getDeclaredMethod("start");
+                start.setAccessible(true);
+                start.invoke(gifFrameLoader);
+            } else {
+                Method stop = gifFrameLoaderClass.getDeclaredMethod("stop");
+                stop.setAccessible(true);
+                stop.invoke(gifFrameLoader);
+            }
+        } catch(NoSuchMethodException | IllegalAccessException | InvocationTargetException | ClassNotFoundException | NoSuchFieldException e) {
+            e.printStackTrace();
+        }
+    }
+}


### PR DESCRIPTION
Part of my change to get looping gifs to work properly was adding the following code, effectively setting how many times the animation should loop and then restarting it from the beginning:

drawable.setLoopCount(loopCount);
drawable.stop();
drawable.startFromFirstFrame(); 

While this works most of the time, unfortunately due to bugs within the `glide` library (which FastImage uses for its android implementation), `startFromFirstFrame()` will occasionally throw an exception if the animation is already running, and `stop()` doesn't actually guarantee it isn't.

The issue is that while `drawable.stop()` succeeds in stopping the animation, it fails to stop the underlying `gifFrameLoader`. Because that is still running, we get an exception when we call `startFromFirstFrame()`.

Unfortunately, this bug lives in `glide` and not FastImage itself. We can't change the glide library directly without creating yet another custom package, so instead we have to do some pretty hacky reflection to get the underlying object and stop it manually.

See this post for more info: https://github.com/bumptech/glide/issues/3445
